### PR TITLE
fix Amber login using Activity Result API instead of callback URL

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:launchMode="singleTop"
+            android:launchMode="singleTask"
             android:theme="@style/Theme.Unfiltered">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/nostr/unfiltered/MainActivity.kt
+++ b/app/src/main/java/com/nostr/unfiltered/MainActivity.kt
@@ -42,6 +42,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
+        setIntent(intent)
         // Handle Amber callback when returning from Amber app
         handleAmberCallback(intent)
     }

--- a/app/src/main/java/com/nostr/unfiltered/nostr/KeyManager.kt
+++ b/app/src/main/java/com/nostr/unfiltered/nostr/KeyManager.kt
@@ -190,16 +190,11 @@ class KeyManager @Inject constructor(
     }
 
     /**
-     * Create intent to get public key from Amber
+     * Create intent to get public key from Amber (NIP-55)
      */
     fun createAmberGetPublicKeyIntent(): Intent {
-        return Intent(Intent.ACTION_VIEW).apply {
-            data = Uri.Builder()
-                .scheme("nostrsigner")
-                .authority("get_public_key")
-                .appendQueryParameter("callbackUrl", "nostr-unfiltered://callback")
-                .build()
-            addCategory(Intent.CATEGORY_BROWSABLE)
+        return Intent(Intent.ACTION_VIEW, Uri.parse("nostrsigner:")).apply {
+            putExtra("type", "get_public_key")
         }
     }
 
@@ -252,7 +247,7 @@ class KeyManager @Inject constructor(
     }
 
     /**
-     * Save public key received from Amber
+     * Save public key received from Amber (npub format)
      */
     fun saveAmberPublicKey(npub: String): Result<Unit> {
         return try {
@@ -270,6 +265,38 @@ class KeyManager @Inject constructor(
             Result.success(Unit)
         } catch (e: Exception) {
             Result.failure(e)
+        }
+    }
+
+    /**
+     * Save public key received from Amber (handles both hex and npub formats)
+     */
+    fun saveAmberPublicKeyAny(pubkeyString: String): Result<Unit> {
+        return try {
+            val trimmed = pubkeyString.trim()
+
+            // Try to parse as npub first, then as hex
+            val pubkey = when {
+                trimmed.startsWith("npub1") -> PublicKey.fromBech32(trimmed)
+                trimmed.length == 64 && trimmed.all { it.isDigit() || it in 'a'..'f' || it in 'A'..'F' } ->
+                    PublicKey.fromHex(trimmed)
+                else -> throw IllegalArgumentException(
+                    "Unrecognized format (len=${trimmed.length}, first20='${trimmed.take(20)}')"
+                )
+            }
+            val npub = pubkey.toBech32()
+
+            securePrefs.edit()
+                .putString("npub", npub)
+                .putBoolean("amber_connected", true)
+                .remove("nsec") // Never store nsec when using Amber
+                .apply()
+
+            cachedKeys = null
+            _authState.value = AuthState.AUTHENTICATED_AMBER
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(Exception("Received '${pubkeyString.take(30)}...': ${e.message}"))
         }
     }
 

--- a/app/src/main/java/com/nostr/unfiltered/ui/screens/auth/AuthScreen.kt
+++ b/app/src/main/java/com/nostr/unfiltered/ui/screens/auth/AuthScreen.kt
@@ -85,11 +85,12 @@ fun AuthScreen(
     }
     val pendingCallback by keyManager.pendingAmberCallback.collectAsState()
 
-    // Amber activity launcher
+    // Amber activity launcher (NIP-55)
     val amberLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartActivityForResult()
     ) { result ->
-        // Amber returns result via callback URL, handled in MainActivity
+        // Handle result from Amber via Activity Result API
+        viewModel.handleAmberActivityResult(result.resultCode, result.data)
     }
 
     // Handle pending Amber callback


### PR DESCRIPTION
NIP-55 for native Android apps requires using the Activity Result API to receive the public key, not deep link callbacks (which are for web apps).

- Change launchMode to singleTask for proper activity lifecycle
- Use Intent extras with "type" = "get_public_key" per NIP-55 spec
- Handle result via ActivityResultContracts.StartActivityForResult
- Support both npub and hex public key formats from Amber