### PR TITLE
Fix Amber signing for likes and persist liked state across refresh

### DIFF
--- a/app/src/main/java/com/nostr/unfiltered/ui/screens/profile/ProfileEditScreen.kt
+++ b/app/src/main/java/com/nostr/unfiltered/ui/screens/profile/ProfileEditScreen.kt
@@ -64,8 +64,10 @@ fun ProfileEditScreen(
         contract = ActivityResultContracts.StartActivityForResult()
     ) { result ->
         result.data?.let { data ->
-            val signedEvent = data.getStringExtra("signature")
-                ?: data.getStringExtra("event")
+            // Amber may return signed event under different extra keys
+            val signedEvent = data.getStringExtra("event")
+                ?: data.getStringExtra("signature")
+                ?: data.getStringExtra("result")
             if (signedEvent != null) {
                 viewModel.handleAmberSignedEvent(signedEvent)
             } else {

--- a/app/src/main/java/com/nostr/unfiltered/ui/screens/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/nostr/unfiltered/ui/screens/profile/ProfileScreen.kt
@@ -66,6 +66,7 @@ fun ProfileScreen(
             // Amber returns the signed event in various possible extras
             val signedEvent = result.data?.getStringExtra("event")
                 ?: result.data?.getStringExtra("signature")
+                ?: result.data?.getStringExtra("result")
             if (signedEvent != null) {
                 viewModel.handleAmberSignedFollow(signedEvent)
             } else {

--- a/app/src/main/java/com/nostr/unfiltered/viewmodel/FeedViewModel.kt
+++ b/app/src/main/java/com/nostr/unfiltered/viewmodel/FeedViewModel.kt
@@ -49,6 +49,9 @@ class FeedViewModel @Inject constructor(
     private val _zapState = MutableStateFlow<ZapState>(ZapState.Idle)
     val zapState: StateFlow<ZapState> = _zapState.asStateFlow()
 
+    // Amber like signing flow
+    val pendingLikeIntent: StateFlow<Intent?> = feedRepository.pendingLikeIntent
+
     private val _feedMode = MutableStateFlow(FeedMode.TRENDING)
     val feedMode: StateFlow<FeedMode> = _feedMode.asStateFlow()
 
@@ -188,6 +191,14 @@ class FeedViewModel @Inject constructor(
 
     fun likePost(post: PhotoPost) {
         feedRepository.likePost(post)
+    }
+
+    fun handleAmberSignedLike(signedEventJson: String) {
+        feedRepository.handleAmberSignedLike(signedEventJson)
+    }
+
+    fun clearPendingLikeIntent() {
+        feedRepository.clearPendingLikeIntent()
     }
 
     fun loadMorePosts() {


### PR DESCRIPTION
- Handle both full signed event JSON and signature-only responses from Amber
- Store unsigned events to reconstruct signed events when Amber returns just a signature
- Add "result" as fallback key when extracting signed events from Amber responses
- Track user's liked posts via subscription to kind 7 (reaction) events
- Persist liked state when navigating away and refreshing the feed
- Apply same fixes to follow/unfollow, create post, and profile edit flows